### PR TITLE
#6 조회수 관리 기능

### DIFF
--- a/src/main/java/toy/blog/be/domain/entity/Post.java
+++ b/src/main/java/toy/blog/be/domain/entity/Post.java
@@ -46,7 +46,6 @@ public class Post {
         this.modifiedAt = now;
     }
 
-    //todo: keyword 아직 구현 안 됨
     public void update(String title, String content, String writerId, Set<String> keywordIds) {
         this.title = title;
         this.content = content;

--- a/src/main/java/toy/blog/be/domain/entity/Post.java
+++ b/src/main/java/toy/blog/be/domain/entity/Post.java
@@ -47,14 +47,18 @@ public class Post {
     }
 
     //todo: keyword 아직 구현 안 됨
-    public void update(String title, String content, String writerId, Set<String> keywordIds){
-        this.title =title;
+    public void update(String title, String content, String writerId, Set<String> keywordIds) {
+        this.title = title;
         this.content = content;
         this.writerId = writerId;
         this.keywordIds = keywordIds;
 
         this.modifiedAt = LocalDateTime.now();
 
+    }
+
+    public void increaseViewCount() {
+        viewCount++;
     }
 
 }

--- a/src/main/java/toy/blog/be/service/PostService.java
+++ b/src/main/java/toy/blog/be/service/PostService.java
@@ -46,10 +46,12 @@ public class PostService {
         return new PagedResponse<>(response, converter);
     }
 
-    @Transactional(readOnly = true)
+    @Transactional // readOnly 속성주면 post.increaseViewCount() 동작 안 함!!
     public PostResponse getPost(String id) {
         var post = postRepository.findById(id)
                 .orElseThrow(EntityNotFoundException::new);
+
+        post.increaseViewCount();
 
         return converter.apply(post);
     }

--- a/src/main/java/toy/blog/be/service/PostService.java
+++ b/src/main/java/toy/blog/be/service/PostService.java
@@ -26,7 +26,7 @@ public class PostService {
     private final PostRepository postRepository;
     private final KeywordRepository keywordRepository;
 
-    Function<Post, PostResponse> converter = post ->    //todo: keyword 추가 필요
+    Function<Post, PostResponse> converter = post ->
             PostResponse.builder()
                     .id(post.getId())
                     .title(post.getTitle())


### PR DESCRIPTION
### 구현 내용
- post get할 때 조회수 1씩 증가하도록 구현.

### 간단한 오류 해결
- @Transactional에서 readOnly 옵션 이슈.
  - get 요청이라고해서 readOnly 옵션을 주게되면 post.increaseViewCount()가 DB에 적용되지 않음!

### 추가 고민해 볼 부분
- 캐시를 적용하게 되면 조회수 증가는 어떻게 처리할것인지?