### PR TITLE
#44 REST API 예외 처리

### DIFF
--- a/src/main/java/toy/blog/be/controller/exception/GlobalExceptionHandler.java
+++ b/src/main/java/toy/blog/be/controller/exception/GlobalExceptionHandler.java
@@ -1,0 +1,70 @@
+package toy.blog.be.controller.exception;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+
+import javax.persistence.EntityNotFoundException;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler({EntityNotFoundException.class})
+    protected ResponseEntity<Object> handleEntityNotFound(EntityNotFoundException exception) {
+        var msg = exception.getMessage();
+
+        log.error(exception.getMessage(), exception);
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(new ExceptionResponse<>(HttpStatus.NOT_FOUND, msg));
+    }
+
+    @ExceptionHandler({IllegalArgumentException.class})
+    protected ResponseEntity<Object> handleIllegalArguments(IllegalArgumentException exception) {
+        var msg = exception.getMessage();
+
+        log.error(exception.getMessage(), exception);
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ExceptionResponse<>(HttpStatus.BAD_REQUEST, msg));
+    }
+
+    @ExceptionHandler({HttpRequestMethodNotSupportedException.class})
+    protected ResponseEntity<Object> handleIllegalArguments(HttpRequestMethodNotSupportedException exception, WebRequest webRequest) {
+        var msg = exception.getMessage();
+        var params = webRequest.getParameterMap().entrySet();
+
+        log.error(exception.getMessage(), exception);
+
+        return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED)
+                .body(new ExceptionResponse<>(HttpStatus.METHOD_NOT_ALLOWED, msg));
+    }
+
+    @ExceptionHandler({Exception.class})
+    protected ResponseEntity<Object> handleServerExceptions(Exception exception, WebRequest webRequest) {
+        var msg = exception.getMessage();
+
+        log.error(exception.getMessage(), exception);
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ExceptionResponse<>(HttpStatus.INTERNAL_SERVER_ERROR, msg));
+    }
+
+
+    @Getter
+    private static class ExceptionResponse<T> {
+        private final T status;
+        private final T msg;
+
+        ExceptionResponse(T status, T msg) {
+            this.status = status;
+            this.msg = msg;
+        }
+    }
+
+}


### PR DESCRIPTION
### 구현
- RestControllerAdvice를 이용하여 rest api에 대한 예외 처리
- 현재 400,404,405,500으로 분류하여 처리.
  - 400,404,405에 걸리지 않은 예외는 모두 500으로 처리

### 고민
- 어떤 종류의 예외들을 처리해야 할지?
- 각 예외에 대한 코드가 비슷해서 중복코드가 발생
- 예외 시 추가로 리턴할 정보가 있을지