### PR TITLE
#20 apply queryDSL, add follow API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,13 @@
+buildscript {
+    ext {
+        queryDslVersion = "5.0.0"
+    }
+}
+
 plugins {
     id 'org.springframework.boot' version '2.7.4'
     id 'io.spring.dependency-management' version '1.0.14.RELEASE'
+    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
     id 'java'
 }
 
@@ -13,11 +20,11 @@ jar {
     enabled = false
 }
 
-configurations {
-    compileOnly {
-        extendsFrom annotationProcessor
-    }
-}
+//configurations {
+//    compileOnly {
+//        extendsFrom annotationProcessor
+//    }
+//}
 
 repositories {
     mavenCentral()
@@ -39,7 +46,7 @@ dependencies {
 
     implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.6.1'
 
-    implementation group: 'com.h2database', name: 'h2', version: '2.1.210'
+    implementation group: 'com.h2database', name: 'h2', version: '2.1.212'
 
     implementation group: 'org.mariadb.jdbc', name: 'mariadb-java-client', version: '3.0.8'
     implementation 'org.springframework.security:spring-security-oauth2-client'
@@ -50,8 +57,32 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+    implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+def querydslDir = "$buildDir/generated/querydsl"
+// JPA 사용 여부와 사용할 경로를 설정
+querydsl {
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+// build 시 사용할 sourceSet 추가
+sourceSets {
+    main.java.srcDir querydslDir
+}
+// querydsl 컴파일시 사용할 옵션 설정
+compileQuerydsl{
+    options.annotationProcessorPath = configurations.querydsl
+}
+// querydsl 이 compileClassPath 를 상속하도록 설정
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+    querydsl.extendsFrom compileClasspath
 }

--- a/src/main/java/toy/blog/be/config/QuerydslConfig.java
+++ b/src/main/java/toy/blog/be/config/QuerydslConfig.java
@@ -1,0 +1,18 @@
+package toy.blog.be.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class QuerydslConfig {
+    private final EntityManager em;
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/toy/blog/be/controller/follow/api/FollowApiController.java
+++ b/src/main/java/toy/blog/be/controller/follow/api/FollowApiController.java
@@ -7,17 +7,24 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import toy.blog.be.controller.follow.dto.FollowID;
+import toy.blog.be.controller.follow.dto.FollowResponse;
 import toy.blog.be.domain.entity.OAuthUserInfo;
 import toy.blog.be.service.FollowService;
 
 import javax.validation.Valid;
 import java.util.List;
+import java.util.function.Function;
 
 @RequestMapping("/follow")
 @RequiredArgsConstructor
 @RestController
 public class FollowApiController {
     private final FollowService followService;
+
+    private Function<List<OAuthUserInfo>, FollowResponse> converter = oAuthUserInfos -> FollowResponse.builder()
+            .oAuthUserInfos(oAuthUserInfos)
+            .build();
+
     @GetMapping("/create-follow")
     public ResponseEntity<Void> createFollow(@RequestBody @Valid FollowID followID) {
         var id = followService.createFollow(
@@ -37,15 +44,15 @@ public class FollowApiController {
     }
 
     @GetMapping("/get-follower")
-    public ResponseEntity<List<OAuthUserInfo>> getFollower(String userId) {
+    public FollowResponse getFollower(String userId) {
         var followers = followService.getFollower(userId);
-        return ResponseEntity.ok().body(followers);
+        return converter.apply(followers);
     }
 
     @GetMapping("/get-followee")
-    public ResponseEntity<List<OAuthUserInfo>> getFollowee(String userId) {
-        var followees = followService.getFollower(userId);
-        return ResponseEntity.ok().body(followees);
+    public FollowResponse getFollowee(String userId) {
+        var followees = followService.getFollowee(userId);
+        return converter.apply(followees);
     }
 
     @GetMapping("/count-follower")

--- a/src/main/java/toy/blog/be/controller/follow/api/FollowApiController.java
+++ b/src/main/java/toy/blog/be/controller/follow/api/FollowApiController.java
@@ -1,4 +1,64 @@
 package toy.blog.be.controller.follow.api;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import toy.blog.be.controller.follow.dto.FollowID;
+import toy.blog.be.domain.entity.OAuthUserInfo;
+import toy.blog.be.service.FollowService;
+
+import javax.validation.Valid;
+import java.util.List;
+
+@RequestMapping("/follow")
+@RequiredArgsConstructor
+@RestController
 public class FollowApiController {
+    private final FollowService followService;
+    @GetMapping("/create-follow")
+    public ResponseEntity<Void> createFollow(@RequestBody @Valid FollowID followID) {
+        var id = followService.createFollow(
+                followID.getFollowerId(),
+                followID.getFolloweeId()
+        );
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/cancel-follow")
+    public ResponseEntity<Void> cancelFollow(@RequestBody @Valid FollowID followID) {
+        followService.deleteFollow(
+                followID.getFollowerId(),
+                followID.getFolloweeId()
+        );
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/get-follower")
+    public ResponseEntity<List<OAuthUserInfo>> getFollower(String userId) {
+        var followers = followService.getFollower(userId);
+        return ResponseEntity.ok().body(followers);
+    }
+
+    @GetMapping("/get-followee")
+    public ResponseEntity<List<OAuthUserInfo>> getFollowee(String userId) {
+        var followees = followService.getFollower(userId);
+        return ResponseEntity.ok().body(followees);
+    }
+
+    @GetMapping("/count-follower")
+    public ResponseEntity<Integer> countFollower(String userId) {
+        var count = followService.countFollower(userId);
+        return ResponseEntity.ok().body(count);
+    }
+
+    @GetMapping("/count-followee")
+    public ResponseEntity<Integer> countFollowee(String userId) {
+        var count = followService.countFollowee(userId);
+        return ResponseEntity.ok().body(count);
+    }
+
+
 }

--- a/src/main/java/toy/blog/be/controller/follow/dto/FollowID.java
+++ b/src/main/java/toy/blog/be/controller/follow/dto/FollowID.java
@@ -2,12 +2,17 @@ package toy.blog.be.controller.follow.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotNull;
 import java.io.Serializable;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class FollowID implements Serializable {
+    @NotNull
     private String followerId;
+    @NotNull
     private String followeeId;
 }

--- a/src/main/java/toy/blog/be/controller/follow/dto/FollowList.java
+++ b/src/main/java/toy/blog/be/controller/follow/dto/FollowList.java
@@ -1,0 +1,13 @@
+package toy.blog.be.controller.follow.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import javax.validation.constraints.NotNull;
+
+@Data
+@AllArgsConstructor
+public class FollowList {
+    @NotNull
+    String nickname;
+}

--- a/src/main/java/toy/blog/be/controller/follow/dto/FollowResponse.java
+++ b/src/main/java/toy/blog/be/controller/follow/dto/FollowResponse.java
@@ -1,0 +1,15 @@
+package toy.blog.be.controller.follow.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import toy.blog.be.domain.entity.OAuthUserInfo;
+
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class FollowResponse {
+    List<OAuthUserInfo> oAuthUserInfos;
+}

--- a/src/main/java/toy/blog/be/domain/entity/Follow.java
+++ b/src/main/java/toy/blog/be/domain/entity/Follow.java
@@ -1,6 +1,7 @@
 package toy.blog.be.domain.entity;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import toy.blog.be.controller.follow.dto.FollowID;
@@ -9,6 +10,7 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.IdClass;
 import java.io.Serializable;
+import java.time.LocalDateTime;
 
 @Getter
 @Entity
@@ -19,4 +21,12 @@ public class Follow implements Serializable {
     private String followerId;
     @Id
     private String followeeId;
+    private LocalDateTime followedAt;
+
+    @Builder
+    Follow(String followerId, String followeeId) {
+        this.followerId = followerId;
+        this.followeeId = followeeId;
+        this.followedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/toy/blog/be/repository/FollowRepository.java
+++ b/src/main/java/toy/blog/be/repository/FollowRepository.java
@@ -7,4 +7,8 @@ import toy.blog.be.domain.entity.Follow;
 
 @Repository
 public interface FollowRepository extends JpaRepository<Follow, FollowID> {
+    Long countFollowByFollowerId(String followerId);
+    Long countFollowByFolloweeId(String followeeId);
+//    List<Follow> findAllByFollowerId(String followerId);
+//    List<Follow> findAllByFolloweeId(String followeeId);
 }

--- a/src/main/java/toy/blog/be/repository/FollowRepositoryImpl.java
+++ b/src/main/java/toy/blog/be/repository/FollowRepositoryImpl.java
@@ -1,0 +1,42 @@
+package toy.blog.be.repository;
+
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+import toy.blog.be.domain.entity.OAuthUserInfo;
+import toy.blog.be.domain.entity.QFollow;
+import toy.blog.be.domain.entity.QOAuthUserInfo;
+
+import java.util.List;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class FollowRepositoryImpl {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    QFollow qFollow = QFollow.follow;
+    QOAuthUserInfo qoAuthUserInfo = QOAuthUserInfo.oAuthUserInfo;
+
+    public List<OAuthUserInfo> getFollower(String followeeId) {
+        return jpaQueryFactory
+                .selectFrom(qoAuthUserInfo)
+                .where(qoAuthUserInfo.id.in(JPAExpressions
+                        .select(qFollow.followerId)
+                        .from(qFollow)
+                        .where(qFollow.followeeId.eq(followeeId))))
+                .fetch();
+    }
+
+    public List<OAuthUserInfo> getFollowee(String followerId) {
+        return jpaQueryFactory
+                .selectFrom(qoAuthUserInfo)
+                .where(qoAuthUserInfo.id.in(JPAExpressions
+                        .select(qFollow.followerId)
+                        .from(qFollow)
+                        .where(qFollow.followeeId.eq(followerId))))
+                .fetch();
+    }
+}

--- a/src/main/java/toy/blog/be/service/FollowService.java
+++ b/src/main/java/toy/blog/be/service/FollowService.java
@@ -1,0 +1,64 @@
+package toy.blog.be.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import toy.blog.be.controller.follow.dto.FollowID;
+import toy.blog.be.domain.entity.Follow;
+import toy.blog.be.domain.entity.OAuthUserInfo;
+import toy.blog.be.repository.FollowRepository;
+import toy.blog.be.repository.FollowRepositoryImpl;
+
+import javax.persistence.EntityNotFoundException;
+import javax.transaction.Transactional;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class FollowService {
+    private final FollowRepository followRepository;
+    private final FollowRepositoryImpl followRepositoryImpl;
+
+    @Transactional
+    public String createFollow(String followerId, String followeeId) {
+        var follow = Follow.builder()
+                .followerId(followerId)
+                .followeeId(followeeId)
+                .build();
+
+        return followRepository.save(follow).getFollowerId();
+    }
+
+    @Transactional
+    public void deleteFollow(String followerId, String followeeId) {
+        FollowID followId = new FollowID(followerId, followeeId);
+        var follow = followRepository.findById(followId)
+                .orElseThrow(EntityNotFoundException::new);
+        followRepository.delete(follow);
+    }
+
+    public int countFollower(String userId) {
+        var count = followRepository.countFollowByFolloweeId(userId);
+        return Math.toIntExact(count);
+    }
+
+    public int countFollowee(String userId) {
+        var count = followRepository.countFollowByFollowerId(userId);
+        return Math.toIntExact(count);
+    }
+
+    @Transactional
+    public List<OAuthUserInfo> getFollower(String followeeId) {
+        var followers = followRepositoryImpl.getFollower(followeeId);
+        return followers; // TODO: list size 0 일때 처리 해줘야함
+    }
+
+
+    @Transactional
+    public List<OAuthUserInfo> getFollowee(String followerId) {
+        var followees = followRepositoryImpl.getFollowee(followerId);
+        return followees; // TODO: list size 0 일때 처리 해줘야함
+    }
+
+}

--- a/src/test/java/toy/blog/be/repository/FollowRepositoryImplTest.java
+++ b/src/test/java/toy/blog/be/repository/FollowRepositoryImplTest.java
@@ -1,0 +1,6 @@
+package toy.blog.be.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FollowRepositoryImplTest {
+}


### PR DESCRIPTION
- 추가된 follow 관련 API: create-follow, cancel-follow, get-follower, get-followee, count-follower, count-followee
- follower 목록, followee 목록 조회할 때, JPA 사용하면 N + 1 query 문제 발생 &rarr; queryDSL 적용하여 해결
- queryDSL
  -  밸덩, 공식 문서에는 Maven 설정방법만 있습니다.
  - [링크](https://dingdingmin-back-end-developer.tistory.com/entry/Spring-Data-JPA-7-Querydsl-%EC%82%AC%EC%9A%A9-gradle-7x) 참고하시면 이해되실 겁니다!